### PR TITLE
Update default port and path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+/data

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ $ ./runtilesv.sh
 ```
 `runtilesv.sh`は、TileserverGLのDockerコンテナを作成し mbtiles を配信します。  
 以下のオプションを指定できます。  
-* `-d`：`oceanus.mbtiles`が存在するディレクトリを指定します。（未指定時は`/tmp`）
-* `-p`：配信ポート番号を指定します。（未指定時は`80`）
+* `-d`：`oceanus.mbtiles`が存在するディレクトリを指定します。（未指定時は`./data`）
+* `-p`：配信ポート番号を指定します。（未指定時は`8080`）
 * `-n`：TileserverGLのコンテナ名を指定します。（未指定時は`tilesv`）
 
 ### 地図の表示

--- a/oceanus.sh
+++ b/oceanus.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -ex
 
-DIR="/tmp"
+DIR=$(pwd)/data
+mkdir -p $DIR
+
 while getopts ":d:h" OPT; do
     case "$OPT" in
         d)

--- a/runtilesv.sh
+++ b/runtilesv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 CONTAINER_NAME="tilesv"
-DIR="/tmp"
-PORTNO=80
+DIR="$(pwd)/data"
+PORTNO=8080
 
 while getopts ":d:p:n:h" OPT; do
     case "$OPT" in


### PR DESCRIPTION
コマンドラインツールの以下のデフォルト値を変更しました。

* ビルドしたタイルのパスを `$(pwd)/data` に変更ドキュメントをよく読まなくても分かるようにした。
* well-known port をデフォルトとすることはセキュリティ的に好ましくないため、タイルサーバーのデフォルトのポートを `8080` に変更。 

`/tmp` にしたのは僕がうまく伝えれてなかったからかもですが、タイルのビルドのためにダウンロードすることが必要な各種のファイルは `/tmp` のほうが良いと思いますが、生成されたタイルは作業ディレクトリ以下のほうがわかりやすいかなと思います。