### PR TITLE
Embed API の読み込み先を変更

### DIFF
--- a/docs/oceanus.html
+++ b/docs/oceanus.html
@@ -27,7 +27,7 @@
   <div class="mapbox-attribution-container">
     <a href="https://www.naturalearthdata.com/downloads/">出典 Natural Earth</a>
   </div>
-<script src="https://api.geolonia.com/dev/embed?geolonia-api-key=YOUR-API-KEY"></script>
+<script src="https://cdn.geolonia.com/dev/embed?geolonia-api-key=YOUR-API-KEY"></script>
  <script>
   var map = new mapboxgl.Map({
     container: '#map',


### PR DESCRIPTION
`https://api.geolonia.com/dev/embed` は廃止予定のため、`https://cdn.geolonia.com/dev/embed`  から読み込むように修正しました。